### PR TITLE
Made links clickable in reactive-sequence example

### DIFF
--- a/reactive-sequence/ui.js
+++ b/reactive-sequence/ui.js
@@ -128,9 +128,7 @@
 		}
 	}
 
-	function *insertMyFeedItem(token) {
-		var feed_id = token.messages[0];
-		var $item = token.messages[1];
+	function *insertMyFeedItem(feed_id, $item) {
 		var $floating_item = $item.clone().addClass("floating");
 
 		if (feed_id == 1) $floating_item.addClass("first-list");


### PR DESCRIPTION
Fix bug with adding items from side lists into the central list in reactive-sequence example. 
insertFeedItem function gets two arguments with feed_id and items, instead of one token.
Issue: #4 